### PR TITLE
Externalize main args to yaml configurations

### DIFF
--- a/configs/la-pipelines-local.yaml
+++ b/configs/la-pipelines-local.yaml
@@ -1,4 +1,8 @@
 # Here we can override some config from la-pipelines.yml instead of modifing it.
+# This is useful during upgrades via debian packaging so we can maintain 
+# la-pipelines.yml without modifications and updated as a configuration reference
+# while doing local modifications here (manually or via ansible).
+#
 # For instance:
 
 # general:

--- a/configs/la-pipelines-local.yaml
+++ b/configs/la-pipelines-local.yaml
@@ -1,4 +1,4 @@
-# Here we can override some config from la-pipelines.yml instead of modifing it.
+# Here we can override some config from la-pipelines.yml instead of modifying it.
 # This is useful during upgrades via debian packaging so we can maintain 
 # la-pipelines.yml without modifications and updated as a configuration reference
 # while doing local modifications here (manually or via ansible).

--- a/configs/la-pipelines-local.yaml
+++ b/configs/la-pipelines-local.yaml
@@ -1,0 +1,5 @@
+# Here we can override some config from la-pipelines.yml instead of modifing it.
+# For instance:
+
+# general:
+#  targetPath: /some-other-moint-point/pipelines-data

--- a/configs/la-pipelines-spark-cluster.yaml
+++ b/configs/la-pipelines-spark-cluster.yaml
@@ -1,3 +1,7 @@
 interpret:
   name: interpret {datasetId}
   appName: Interpretation for {datasetId}
+
+sample-avro:
+  appName: Add Sampling for {datasetId}
+  useExtendedRecordId: true

--- a/configs/la-pipelines-spark-cluster.yaml
+++ b/configs/la-pipelines-spark-cluster.yaml
@@ -2,6 +2,11 @@ interpret:
   name: interpret {datasetId}
   appName: Interpretation for {datasetId}
 
+uuid:
+  interpretationTypes: ALL
+  useExtendedRecordId: true
+  skipRegisrtyCalls: true
+
 sample-avro:
   appName: Add Sampling for {datasetId}
   useExtendedRecordId: true

--- a/configs/la-pipelines-spark-cluster.yaml
+++ b/configs/la-pipelines-spark-cluster.yaml
@@ -1,0 +1,3 @@
+interpret:
+  name: interpret {datasetId}
+  appName: Interpretation for {datasetId}

--- a/configs/la-pipelines-spark-cluster.yaml
+++ b/configs/la-pipelines-spark-cluster.yaml
@@ -10,3 +10,7 @@ uuid:
 sample-avro:
   appName: Add Sampling for {datasetId}
   useExtendedRecordId: true
+
+index:
+  appName: SOLR indexing for {datasetId}
+  runner: SparkRunner

--- a/configs/la-pipelines-spark-embedded.yaml
+++ b/configs/la-pipelines-spark-embedded.yaml
@@ -1,2 +1,5 @@
 interpret:
   appName: Interpretation for {datasetId}
+
+sample-avro:
+  appName: SamplingToAvro indexing for {datasetId}

--- a/configs/la-pipelines-spark-embedded.yaml
+++ b/configs/la-pipelines-spark-embedded.yaml
@@ -3,3 +3,7 @@ interpret:
 
 sample-avro:
   appName: SamplingToAvro indexing for {datasetId}
+
+index:
+  appName: SOLR indexing for {datasetId}
+  runner: SparkRunner

--- a/configs/la-pipelines-spark-embedded.yaml
+++ b/configs/la-pipelines-spark-embedded.yaml
@@ -1,0 +1,2 @@
+interpret:
+  appName: Interpretation for {datasetId}

--- a/configs/la-pipelines.yaml
+++ b/configs/la-pipelines.yaml
@@ -31,6 +31,17 @@ interpret:
   ## For spark-embedded:
   #  appName: Interpretation for {datasetId}
 
+uuid:
+  appName: UUID minting for {datasetId}
+  runner: SparkRunner
+  inputPath: /data/pipelines-data
+  metaFileName: uuid-metrics.yml
+  properties: ../scripts/pipelines.yaml
+  ## For spark-cluster:
+  # interpretationTypes: ALL
+  # useExtendedRecordId: true
+  # skipRegisrtyCalls: true
+
 export-latlng:
   inputPath: /data/pipelines-data
   runner: SparkRunner
@@ -57,25 +68,11 @@ sample-avro:
   # appName: SamplingToAvro indexing for {datasetId}
 
 migrate-uuids:
-  default:
-    runner: SparkRunner
-    metaFileName: uuid-metrics.yml
-    targetPath: /data/pipelines-data
-    inputPath: /data/pipelines-data/occ_uuid.csv
-  #java -Xmx24g -Xmx24g -XX:+UseG1GC
-  test:
-    runner: DirectRunner
+  inputPath: /data/pipelines-data/occ_uuid.csv
+  targetPath: /data/pipelines-data
+  hdfsSiteConfig: ""
+  # FIXME: MigrateUUIDPipeline should use this also?
 
-# java -Xmx8g -Xmx8g -XX:+UseG1GC
-uuid:
-  embedded:
-    appName: UUID minting for {datasetId}
-    runner: SparkRunner
-    inputPath: /data/pipelines-data
-    metaFileName: uuid-metrics.yml
-#--properties=pipelines.properties
-
-#java -Xmx8g -XX:+UseG1GC -
 index:
   default:
     inputPath: /data/pipelines-data

--- a/configs/la-pipelines.yaml
+++ b/configs/la-pipelines.yaml
@@ -37,20 +37,25 @@ export-latlng:
   appName: Lat Long export for {datasetId}
 
 sample:
-  default:
-  cluster:
-    # TODO
-  avro-cluster:
-    # TODO
-# java -Xmx8g -Xmx8g -XX:+UseG1GC
-  embedded:
-    appName: SamplingToAvro indexing for {datasetId}
-    runner: SparkRunner
-    inputPath: /data/pipelines-data
-    metaFileName: indexing-metrics.yml
-#--properties=pipelines.properties
+  inputPath: /data/pipelines-data
+  appName: Sample for {datasetId}
+  metaFileName: indexing-metrics.yml
+  runner: SparkRunner
+  # TODO improve/move this
+  properties: ../scripts/pipelines.yaml
 
-#java -Xmx8g -Xmx8g -XX:+UseG1GC -
+sample-avro:
+  inputPath: /data/pipelines-data
+  runner: SparkRunner
+  metaFileName: indexing-metrics.yml
+  # TODO improve/move this
+  properties: ../scripts/pipelines.yaml
+  ## For spark-cluster:
+  # appName: Add Sampling for {datasetId}
+  # useExtendedRecordId: true
+  ## For spark-embedded:
+  # appName: SamplingToAvro indexing for {datasetId}
+
 migrate-uuids:
   default:
     runner: SparkRunner

--- a/configs/la-pipelines.yaml
+++ b/configs/la-pipelines.yaml
@@ -74,21 +74,15 @@ migrate-uuids:
   # FIXME: MigrateUUIDPipeline should use this also?
 
 index:
-  default:
-    inputPath: /data/pipelines-data
-    metaFileName: indexing-metrics.yml
-  java:
-    #--properties=pipelines.properties \
-    includeSampling: true
-    zkHost: localhost:9983
-    solrCollection: biocache
-  spark-cluster:
-    # TODO
-  # java -Xmx8g -Xmx8g -XX:+UseG1GC
-  spark-embedded:
-    appName: SOLR indexing for {datasetId}
-    runner: SparkRunner
-#    properties: pipelines.properties
-    zkHost: localhost:9983
-    solrCollection: biocache
-    includeSampling: true
+  inputPath: /data/pipelines-data
+  metaFileName: indexing-metrics.yml
+  properties: ../scripts/pipelines.yaml
+  solrCollection: biocache
+  includeSampling: true
+  zkHost: localhost:9983
+  ## For spark-cluster:
+  # appName: SOLR indexing for {datasetId}
+  # runner: SparkRunner
+  ## For spark-embedded:
+  # appName: SOLR indexing for {datasetId}
+  # runner: SparkRunner

--- a/configs/la-pipelines.yaml
+++ b/configs/la-pipelines.yaml
@@ -104,5 +104,3 @@ index:
     zkHost: localhost:9983
     solrCollection: biocache
     includeSampling: true
-
-test-delete: 1

--- a/configs/la-pipelines.yaml
+++ b/configs/la-pipelines.yaml
@@ -17,33 +17,19 @@ dwca-avro:
   metaFileName: dwca-metrics.yml
   inputPath: /data/biocache-load/{datasetId}
 
-#--inputPath: $dwca_dir
-
-#java -Xmx2g -XX:+UseG1GC  -Dspark.master=local[*]
-# java -Xmx8g -XX:+UseG1GC  -Dspark.master=local[*] # spark-embedded
-interpret: # (java)
-  default:
-    interpretationTypes: ALL
-    inputPath: /data/pipelines-data/{datasetId}/1/verbatim.avro
-    metaFileName: interpretation-metrics.yml
-    useExtendedRecordId: true
-    skipRegisrtyCalls: true
-    #  properties: pipelines.properties
-  spark-cluster:
-    name: interpret {datasetId}
-    appName: Interpretation for {datasetId}
-    runner: SparkRunner
-    #--properties=/efs-mount-point/pipelines.properties
-    # num-executors: 24
-    # executor-cores: 8
-    # executor-memory: 7G
-    # driver-memory: 1G
-#--conf spark.default.parallelism=192
-#--conf spark.yarn.submit.waitAppCompletion=false
-    master: spark://172.30.1.102:7077
-    driver-java-options: -Dlog4j.configuration=file:/efs-mount-point/log4j.properties
-  spark-embedded:
-    runner: SparkRunner
+interpret:
+  interpretationTypes: ALL
+  inputPath: /data/pipelines-data/{datasetId}/1/verbatim.avro
+  metaFileName: interpretation-metrics.yml
+  useExtendedRecordId: true
+  runner: SparkRunner
+  # TODO improve/move this
+  properties: ../scripts/pipelines.yaml
+  ## For spark-cluster:
+  #  name: interpret {datasetId}
+  #  appName: Interpretation for {datasetId}
+  ## For spark-embedded:
+  #  appName: Interpretation for {datasetId}
 
 export-latlng:
   inputPath: /data/pipelines-data

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -582,6 +582,11 @@
       <artifactId>jsr305</artifactId>
       <version>${findbugs-jsr305.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.25</version>
+    </dependency>
 
     <!-- XML -->
     <dependency>

--- a/pipelines/pom.xml
+++ b/pipelines/pom.xml
@@ -587,6 +587,11 @@
       <artifactId>snakeyaml</artifactId>
       <version>1.25</version>
     </dependency>
+    <dependency>
+      <groupId>one.util</groupId>
+      <artifactId>streamex</artifactId>
+      <version>0.7.2</version>
+    </dependency>
 
     <!-- XML -->
     <dependency>

--- a/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToLatLongCSVPipeline.java
+++ b/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAInterpretedToLatLongCSVPipeline.java
@@ -2,6 +2,7 @@ package au.org.ala.pipelines.beam;
 
 import au.org.ala.pipelines.transforms.ALACSVDocumentTransform;
 import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +42,8 @@ import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.AVRO_EXTENSI
 public class ALAInterpretedToLatLongCSVPipeline {
 
     public static void main(String[] args) throws Exception {
-        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(args);
+        String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "export-latlng");
+        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(combinedArgs);
         run(options);
     }
 

--- a/pipelines/src/main/java/au/org/ala/pipelines/beam/ALASamplingToAvroPipeline.java
+++ b/pipelines/src/main/java/au/org/ala/pipelines/beam/ALASamplingToAvroPipeline.java
@@ -2,6 +2,7 @@ package au.org.ala.pipelines.beam;
 
 import au.com.bytecode.opencsv.CSVReader;
 import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,8 +42,9 @@ import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ALASamplingToAvroPipeline {
 
-    public static void main(String[] args) {
-        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(args);
+    public static void main(String[] args) throws FileNotFoundException {
+        String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "sample-avro");
+        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(combinedArgs);
         run(options);
     }
 

--- a/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDMintingPipeline.java
+++ b/pipelines/src/main/java/au/org/ala/pipelines/beam/ALAUUIDMintingPipeline.java
@@ -6,6 +6,7 @@ import au.org.ala.kvs.cache.ALAAttributionKVStoreFactory;
 import au.org.ala.kvs.client.ALACollectoryMetadata;
 import au.org.ala.pipelines.common.ALARecordTypes;
 import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -75,7 +76,8 @@ public class ALAUUIDMintingPipeline {
     public static final String UNIQUE_COMPOSITE_KEY_JOIN_CHAR = "|";
 
     public static void main(String[] args) throws Exception {
-        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(args);
+        String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "uuid");
+        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(combinedArgs);
         run(options);
     }
 

--- a/pipelines/src/main/java/au/org/ala/pipelines/beam/DwcaToVerbatimPipeline.java
+++ b/pipelines/src/main/java/au/org/ala/pipelines/beam/DwcaToVerbatimPipeline.java
@@ -1,5 +1,6 @@
 package au.org.ala.pipelines.beam;
 
+import au.org.ala.utils.CombinedYamlConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -13,6 +14,7 @@ import org.gbif.pipelines.ingest.utils.MetricsHandler;
 import org.gbif.pipelines.transforms.core.VerbatimTransform;
 import org.slf4j.MDC;
 
+import java.io.FileNotFoundException;
 import java.nio.file.Paths;
 
 /**
@@ -22,9 +24,11 @@ import java.nio.file.Paths;
 @Slf4j
 public class DwcaToVerbatimPipeline {
 
-    public static void main(String[] args) {
-        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(args);
-        run(options);
+    public static void main(String[] args) throws FileNotFoundException {
+       String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "dwca-avro");
+       InterpretationPipelineOptions options =
+           PipelinesOptionsFactory.createInterpretation(combinedArgs);
+       run(options);
     }
 
     public static void run(InterpretationPipelineOptions options) {

--- a/pipelines/src/main/java/au/org/ala/pipelines/java/ALAInterpretedToSolrIndexPipeline.java
+++ b/pipelines/src/main/java/au/org/ala/pipelines/java/ALAInterpretedToSolrIndexPipeline.java
@@ -1,5 +1,6 @@
 package au.org.ala.pipelines.java;
 
+import java.io.FileNotFoundException;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -14,6 +15,7 @@ import au.org.ala.pipelines.transforms.ALAAttributionTransform;
 import au.org.ala.pipelines.transforms.ALASolrDocumentTransform;
 import au.org.ala.pipelines.transforms.ALATaxonomyTransform;
 import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import org.apache.solr.common.SolrInputDocument;
 import org.gbif.api.model.pipelines.StepType;
 import org.gbif.pipelines.core.converters.MultimediaConverter;
@@ -89,8 +91,9 @@ import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.AVRO_EXTENSI
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ALAInterpretedToSolrIndexPipeline {
 
-    public static void main(String[] args) {
-        run(args);
+    public static void main(String[] args) throws FileNotFoundException {
+        String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "index");
+        run(combinedArgs);
     }
 
     public static void run(String[] args) {

--- a/pipelines/src/main/java/au/org/ala/pipelines/java/ALAVerbatimToInterpretedPipeline.java
+++ b/pipelines/src/main/java/au/org/ala/pipelines/java/ALAVerbatimToInterpretedPipeline.java
@@ -11,6 +11,7 @@ import au.org.ala.pipelines.transforms.ALADefaultValuesTransform;
 import au.org.ala.pipelines.transforms.ALATaxonomyTransform;
 import au.org.ala.pipelines.transforms.LocationTransform;
 import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
@@ -46,6 +47,7 @@ import org.gbif.pipelines.transforms.extension.MeasurementOrFactTransform;
 import org.gbif.pipelines.transforms.extension.MultimediaTransform;
 import org.slf4j.MDC;
 
+import java.io.FileNotFoundException;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
@@ -103,8 +105,9 @@ import static org.gbif.pipelines.common.PipelinesVariables.Pipeline.Interpretati
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ALAVerbatimToInterpretedPipeline {
 
-    public static void main(String[] args) {
-        run(args);
+    public static void main(String[] args) throws FileNotFoundException {
+        String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "interpret");
+        run(combinedArgs);
     }
 
     public static void run(String[] args) {

--- a/pipelines/src/main/java/au/org/ala/sampling/LayerCrawler.java
+++ b/pipelines/src/main/java/au/org/ala/sampling/LayerCrawler.java
@@ -1,6 +1,7 @@
 package au.org.ala.sampling;
 
 import au.org.ala.utils.ALAFsUtils;
+import au.org.ala.utils.CombinedYamlConfiguration;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hadoop.fs.FileSystem;
@@ -66,7 +67,8 @@ public class LayerCrawler {
                     .build();
 
     public static void main(String[] args) throws Exception  {
-        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(args);
+        String[] combinedArgs = new CombinedYamlConfiguration(args).toArgs("general", "sample");
+        InterpretationPipelineOptions options = PipelinesOptionsFactory.createInterpretation(combinedArgs);
         run(options);
     }
 

--- a/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
+++ b/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
@@ -25,7 +25,11 @@ public class CombinedYamlConfiguration {
       // And we combine the result
       this.mainArgs.put(argPair[0], argPair[1]);
     }
-    String[] yamlConfigPaths = this.mainArgs.get("config").split(",");
+    String config = this.mainArgs.get("config");
+    if (config == null) {
+      throw new RuntimeException("The --config=some.yml argument is missing");
+    }
+    String[] yamlConfigPaths = config.split(",");
     this.mainArgs.remove("config"); // we remove config, because is not an pipeline configuration
     mainArgsAsList =
       new String[][] {
@@ -33,8 +37,8 @@ public class CombinedYamlConfiguration {
         this.mainArgs.values().toArray(new String[0])
       };
 
-    for (String config : yamlConfigPaths) {
-      InputStream input = new FileInputStream(new File(config));
+    for (String path : yamlConfigPaths) {
+      InputStream input = new FileInputStream(new File(path));
       Yaml yaml = new Yaml();
       LinkedHashMap<String, Object> loaded = yaml.load(input);
       combined.putAll(loaded);

--- a/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
+++ b/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
@@ -1,5 +1,7 @@
 package au.org.ala.utils;
 
+import one.util.streamex.EntryStream;
+import org.jetbrains.annotations.NotNull;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
@@ -10,42 +12,101 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public class CombinedYamlConfiguration {
 
-  private final LinkedHashMap<String, Object> combined = new LinkedHashMap<String, Object>();
   private final LinkedHashMap<String, String> mainArgs = new LinkedHashMap<String, String>();
   private final String[][] mainArgsAsList;
+  private LinkedHashMap<String, Object> combined = new LinkedHashMap<String, Object>();
 
-  public CombinedYamlConfiguration(String[] mainArgs)
-      throws FileNotFoundException {
+  public CombinedYamlConfiguration(String[] mainArgs) throws FileNotFoundException {
+    // First: copy main args to map
     for (String arg : mainArgs) {
       // For each arg of type --varName=value we remove the -- and split by = in varName and value
       String[] argPair = arg.replaceFirst("--", "").split("=", 2);
       // And we combine the result
       this.mainArgs.put(argPair[0], argPair[1]);
     }
+    // Look for a config arg to find the yaml file paths that can be comma separated
     String config = this.mainArgs.get("config");
     if (config == null) {
-      throw new RuntimeException("The --config=some.yml argument is missing");
+      throw new RuntimeException(
+          "The --config=\"some-config.yml,some-other.yml\" argument is missing");
     }
     String[] yamlConfigPaths = config.split(",");
-    this.mainArgs.remove("config"); // we remove config, because is not an pipeline configuration
-    mainArgsAsList =
-      new String[][] {
-        this.mainArgs.keySet().toArray(new String[0]),
-        this.mainArgs.values().toArray(new String[0])
-      };
+    // we remove config, because is not an pipeline configuration
+    this.mainArgs.remove("config");
 
+    // Convert the main args to a two-dimensional Array
+    mainArgsAsList =
+        new String[][] {
+          this.mainArgs.keySet().toArray(new String[0]),
+          this.mainArgs.values().toArray(new String[0])
+        };
+
+    // Load each yaml, and combine the values
     for (String path : yamlConfigPaths) {
       InputStream input = new FileInputStream(new File(path));
       Yaml yaml = new Yaml();
       LinkedHashMap<String, Object> loaded = yaml.load(input);
-      combined.putAll(loaded);
+      if (loaded != null) {
+        // This means that config is not empty
+        combined = combineMap(combined, loaded);
+      }
     }
   }
 
-  public LinkedHashMap<String, Object> subSet(String... keys) {
+  /**
+   * Combine linked hash mapS.
+   *
+   * <p>If some keys are maps of values we join them. For instance:
+   *
+   * <pre>
+   *      # map1
+   *      general:
+   *        a: valueA
+   *        b: valueB
+   *
+   *      # map2
+   *      general:
+   *        a: valueA'
+   *        c: valueC
+   *
+   *      # combinedMap:
+   *      general:
+   *        a: valueA'
+   *        b: valueB
+   *        c: valueC
+   * </pre>
+   *
+   * @param map1 the map 1
+   * @param map2 the map 2
+   * @return the merged hash map
+   */
+  private LinkedHashMap<String, Object> combineMap(
+      Map<String, Object> map1, Map<String, Object> map2) {
+    Map<String, Object> map3 =
+        EntryStream.of(map1)
+            .append(EntryStream.of(map2))
+            .toMap(
+                (v1, v2) -> {
+                  if (v1 instanceof Map && v2 instanceof Map) {
+                    return combineMap((Map<String, Object>) v1, (Map<String, Object>) v2);
+                  } else {
+                    return v2;
+                  }
+                });
+    return new LinkedHashMap<>(map3);
+  }
+
+  /**
+   * Sub set of all configurations by some keys
+   *
+   * @param keys the keys you want to restrict
+   * @return the subset map of the configuration
+   */
+  public LinkedHashMap<String, Object> subSet(@NotNull String... keys) {
     LinkedHashMap<String, Object> partial = new LinkedHashMap<String, Object>();
     if (keys.length == 0) {
       return combined;
@@ -66,7 +127,8 @@ public class CombinedYamlConfiguration {
     return partial;
   }
 
-  private LinkedHashMap<String, Object> traverse(String key) {
+  /** We split dot.composed.keys looking for some value in the yaml */
+  private LinkedHashMap<String, Object> traverse(@NotNull String key) {
     String[] keySplitted = key.split("\\.");
     LinkedHashMap<String, Object> current = combined;
     for (String keyS : keySplitted) {
@@ -75,7 +137,7 @@ public class CombinedYamlConfiguration {
     return current;
   }
 
-  private LinkedHashMap<String, Object> toList(String key, Object obj) {
+  private LinkedHashMap<String, Object> toList(@NotNull String key, Object obj) {
     if (obj instanceof LinkedHashMap) {
       return (LinkedHashMap<String, Object>) obj;
     }
@@ -86,13 +148,20 @@ public class CombinedYamlConfiguration {
     return list;
   }
 
-  public String[] toArgs(String... keys) {
+  /**
+   * We obtain an array of --args=values that is the result of concatenated the yaml config files
+   * plus main args
+   *
+   * @param keys to look for in the yamls
+   * @return a list of --args=values
+   */
+  public String[] toArgs(@NotNull String... keys) {
     return toArgs(mainArgsAsList, keys);
   }
 
-  public String[] toArgs(String[][] params, String... keys) {
+  private String[] toArgs(String[][] params, @NotNull String... keys) {
     List<String> argList = new ArrayList<String>();
-    for (Map.Entry<String, Object> conf : subSet(keys).entrySet()) {
+    for (Entry<String, Object> conf : subSet(keys).entrySet()) {
       Object value = format(conf.getValue(), params);
       argList.add(
           new StringBuffer()
@@ -105,6 +174,13 @@ public class CombinedYamlConfiguration {
     return argList.toArray(new String[0]);
   }
 
+  /**
+   * Replace {args} with their values, for instance {datasetId} with some value, like dr893
+   *
+   * @param value
+   * @param params
+   * @return
+   */
   private Object format(Object value, String[][] params) {
     if (value instanceof String) {
       String formatted = (String) value;
@@ -113,6 +189,7 @@ public class CombinedYamlConfiguration {
       }
       return formatted;
     } else {
+      // we only format Strings, in other case we return the same object
       return value;
     }
   }

--- a/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
+++ b/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
@@ -15,16 +15,17 @@ public class CombinedYamlConfiguration {
 
   private final LinkedHashMap<String, Object> combined;
 
-  public CombinedYamlConfiguration(String...configs) throws FileNotFoundException {
+  public CombinedYamlConfiguration(String... configs) throws FileNotFoundException {
     combined = new LinkedHashMap<String, Object>();
     for (String config : configs) {
       InputStream input = new FileInputStream(new File(config));
       Yaml yaml = new Yaml();
-      LinkedHashMap<String, Object> loaded = (LinkedHashMap<String, Object>) yaml.load(input);
+      LinkedHashMap<String, Object> loaded = yaml.load(input);
       combined.putAll(loaded);
     }
   }
-  public LinkedHashMap<String, Object> subSet(String...keys) {
+
+  public LinkedHashMap<String, Object> subSet(String... keys) {
     LinkedHashMap<String, Object> partial = new LinkedHashMap<String, Object>();
     if (keys.length == 0) {
       return combined;
@@ -48,8 +49,7 @@ public class CombinedYamlConfiguration {
     String[] keySplitted = key.split("\\.");
     LinkedHashMap<String, Object> current = combined;
     for (String keyS : keySplitted) {
-      if (current.size() > 0)
-        current = toList(keyS, current.get(keyS));
+      if (current.size() > 0) current = toList(keyS, current.get(keyS));
     }
     return current;
   }
@@ -67,15 +67,15 @@ public class CombinedYamlConfiguration {
 
   public String[] toArgs(String... keys) {
     List<String> argList = new ArrayList<String>();
-      for (Map.Entry<String, Object> conf : subSet(keys).entrySet()) {
-        argList.add(
-            new StringBuffer()
-                .append("--")
-                .append(conf.getKey())
-                .append("=")
-                .append(conf.getValue())
-                .toString());
-      }
+    for (Map.Entry<String, Object> conf : subSet(keys).entrySet()) {
+      argList.add(
+          new StringBuffer()
+              .append("--")
+              .append(conf.getKey())
+              .append("=")
+              .append(conf.getValue())
+              .toString());
+    }
     return argList.toArray(new String[0]);
   }
 
@@ -85,7 +85,7 @@ public class CombinedYamlConfiguration {
       // we try to traverse the tree looking for that var
       LinkedHashMap<String, Object> traversed = traverse(key);
       // If is an object, return the value, if not, the list of values
-      return traversed.size() == 1? traversed.values().toArray()[0]: traversed;
+      return traversed.size() == 1 ? traversed.values().toArray()[0] : traversed;
     }
     return value;
   }

--- a/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
+++ b/pipelines/src/main/java/au/org/ala/utils/CombinedYamlConfiguration.java
@@ -1,0 +1,92 @@
+package au.org.ala.utils;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CombinedYamlConfiguration {
+
+  private final LinkedHashMap<String, Object> combined;
+
+  public CombinedYamlConfiguration(String...configs) throws FileNotFoundException {
+    combined = new LinkedHashMap<String, Object>();
+    for (String config : configs) {
+      InputStream input = new FileInputStream(new File(config));
+      Yaml yaml = new Yaml();
+      LinkedHashMap<String, Object> loaded = (LinkedHashMap<String, Object>) yaml.load(input);
+      combined.putAll(loaded);
+    }
+  }
+  public LinkedHashMap<String, Object> subSet(String...keys) {
+    LinkedHashMap<String, Object> partial = new LinkedHashMap<String, Object>();
+    if (keys.length == 0) {
+      return combined;
+    }
+    for (String key : keys) {
+      LinkedHashMap<String, Object> subList = toList(key, combined.get(key));
+      if (subList.size() > 0) {
+        partial.putAll(subList);
+      } else {
+        // Try to find in the tree if is a var.with.dots
+        if (key.contains(".")) {
+          LinkedHashMap<String, Object> current = traverse(key);
+          partial.putAll(current);
+        }
+      }
+    }
+    return partial;
+  }
+
+  private LinkedHashMap<String, Object> traverse(String key) {
+    String[] keySplitted = key.split("\\.");
+    LinkedHashMap<String, Object> current = combined;
+    for (String keyS : keySplitted) {
+      if (current.size() > 0)
+        current = toList(keyS, current.get(keyS));
+    }
+    return current;
+  }
+
+  private LinkedHashMap<String, Object> toList(String key, Object obj) {
+    if (obj instanceof LinkedHashMap) {
+      return (LinkedHashMap<String, Object>) obj;
+    }
+    LinkedHashMap<String, Object> list = new LinkedHashMap<String, Object>();
+    if (obj != null) {
+      list.put(key, obj);
+    }
+    return list;
+  }
+
+  public String[] toArgs(String... keys) {
+    List<String> argList = new ArrayList<String>();
+      for (Map.Entry<String, Object> conf : subSet(keys).entrySet()) {
+        argList.add(
+            new StringBuffer()
+                .append("--")
+                .append(conf.getKey())
+                .append("=")
+                .append(conf.getValue())
+                .toString());
+      }
+    return argList.toArray(new String[0]);
+  }
+
+  public Object get(String key) {
+    Object value = combined.get(key);
+    if (value == null && key.contains(".")) {
+      // we try to traverse the tree looking for that var
+      LinkedHashMap<String, Object> traversed = traverse(key);
+      // If is an object, return the value, if not, the list of values
+      return traversed.size() == 1? traversed.values().toArray()[0]: traversed;
+    }
+    return value;
+  }
+}

--- a/pipelines/src/main/resources/la-pipelines.yaml
+++ b/pipelines/src/main/resources/la-pipelines.yaml
@@ -1,0 +1,111 @@
+general:
+  gbif.api.url: https://___DONT_USE______xapi.gbif.org
+
+  ala_taxonomy.api.url: http://localhost:9179
+  ala_spatial.api.url: http://localhost:8080
+  ala_collectory.api.url: https://collections.ala.org.au
+  ala_lists.api.url: http://lists.ala.org.au
+  geocode.api.url: http://127.0.0.1:4444/geocode/%
+
+  targetPath: /data/pipelines-data
+  attempt: 1
+
+dwca-avro:
+  runner: SparkRunner
+  metaFileName: dwca-metrics.yml
+#--inputPath: $dwca_dir
+
+#java -Xmx2g -XX:+UseG1GC  -Dspark.master=local[*]
+# java -Xmx8g -XX:+UseG1GC  -Dspark.master=local[*] # spark-embedded
+interpret: # (java)
+  default:
+    interpretationTypes: ALL
+    inputPath: /data/pipelines-data/{0}/1/verbatim.avro
+    metaFileName: interpretation-metrics.yml
+    useExtendedRecordId: true
+    skipRegisrtyCalls: true
+    #  properties: pipelines.properties
+  spark-cluster:
+    name: interpret {0}
+    appName: Interpretation for {0}
+    runner: SparkRunner
+    #--properties=/efs-mount-point/pipelines.properties
+    # num-executors: 24
+    # executor-cores: 8
+    # executor-memory: 7G
+    # driver-memory: 1G
+#--conf spark.default.parallelism=192
+#--conf spark.yarn.submit.waitAppCompletion=false
+    master: spark://172.30.1.102:7077
+    driver-java-options: -Dlog4j.configuration=file:/efs-mount-point/log4j.properties
+  spark-embedded:
+    runner: SparkRunner
+
+export-latlng:
+  default:
+    inputPath: /data/pipelines-data
+  java:
+    appName: Lat Long export for {0}
+  all:
+    appName: Lat Long export for datasets
+    runner: SparkRunner
+    inputPath: /data/pipelines-data
+  cluster:
+  # TODO
+
+sample:
+  default:
+  cluster:
+    # TODO
+  avro-cluster:
+    # TODO
+# java -Xmx8g -Xmx8g -XX:+UseG1GC
+  embedded:
+    appName: SamplingToAvro indexing for {0}
+    runner: SparkRunner
+    inputPath: /data/pipelines-data
+    metaFileName: indexing-metrics.yml
+#--properties=pipelines.properties
+
+#java -Xmx8g -Xmx8g -XX:+UseG1GC -
+migrate-uuids:
+  default:
+    runner: SparkRunner
+    metaFileName: uuid-metrics.yml
+    targetPath: /data/pipelines-data
+    inputPath: /data/pipelines-data/occ_uuid.csv
+  #java -Xmx24g -Xmx24g -XX:+UseG1GC
+  test:
+    runner: DirectRunner
+
+# java -Xmx8g -Xmx8g -XX:+UseG1GC
+uuid:
+  embedded:
+    appName: UUID minting for {0}
+    runner: SparkRunner
+    inputPath: /data/pipelines-data
+    metaFileName: uuid-metrics.yml
+#--properties=pipelines.properties
+
+#java -Xmx8g -XX:+UseG1GC -
+index:
+  default:
+    inputPath: /data/pipelines-data
+    metaFileName: indexing-metrics.yml
+  java:
+    #--properties=pipelines.properties \
+    includeSampling: true
+    zkHost: localhost:9983
+    solrCollection: biocache
+  spark-cluster:
+    # TODO
+  # java -Xmx8g -Xmx8g -XX:+UseG1GC
+  spark-embedded:
+    appName: SOLR indexing for {0}
+    runner: SparkRunner
+#    properties: pipelines.properties
+    zkHost: localhost:9983
+    solrCollection: biocache
+    includeSampling: true
+
+test-delete: 1

--- a/pipelines/src/main/resources/la-pipelines.yaml
+++ b/pipelines/src/main/resources/la-pipelines.yaml
@@ -46,16 +46,9 @@ interpret: # (java)
     runner: SparkRunner
 
 export-latlng:
-  default:
-    inputPath: /data/pipelines-data
-  java:
-    appName: Lat Long export for {datasetId}
-  all:
-    appName: Lat Long export for datasets
-    runner: SparkRunner
-    inputPath: /data/pipelines-data
-  cluster:
-  # TODO
+  inputPath: /data/pipelines-data
+  runner: SparkRunner
+  appName: Lat Long export for {datasetId}
 
 sample:
   default:

--- a/pipelines/src/main/resources/la-pipelines.yaml
+++ b/pipelines/src/main/resources/la-pipelines.yaml
@@ -1,18 +1,22 @@
-general:
+services:
   gbif.api.url: https://___DONT_USE______xapi.gbif.org
-
   ala_taxonomy.api.url: http://localhost:9179
   ala_spatial.api.url: http://localhost:8080
   ala_collectory.api.url: https://collections.ala.org.au
   ala_lists.api.url: http://lists.ala.org.au
   geocode.api.url: http://127.0.0.1:4444/geocode/%
 
+general:
   targetPath: /data/pipelines-data
   attempt: 1
+  hdfsSiteConfig: ""
+  coreSiteConfig: ""
 
 dwca-avro:
   runner: SparkRunner
   metaFileName: dwca-metrics.yml
+  inputPath: /data/biocache-load/{datasetId}
+
 #--inputPath: $dwca_dir
 
 #java -Xmx2g -XX:+UseG1GC  -Dspark.master=local[*]
@@ -20,14 +24,14 @@ dwca-avro:
 interpret: # (java)
   default:
     interpretationTypes: ALL
-    inputPath: /data/pipelines-data/{0}/1/verbatim.avro
+    inputPath: /data/pipelines-data/{datasetId}/1/verbatim.avro
     metaFileName: interpretation-metrics.yml
     useExtendedRecordId: true
     skipRegisrtyCalls: true
     #  properties: pipelines.properties
   spark-cluster:
-    name: interpret {0}
-    appName: Interpretation for {0}
+    name: interpret {datasetId}
+    appName: Interpretation for {datasetId}
     runner: SparkRunner
     #--properties=/efs-mount-point/pipelines.properties
     # num-executors: 24
@@ -45,7 +49,7 @@ export-latlng:
   default:
     inputPath: /data/pipelines-data
   java:
-    appName: Lat Long export for {0}
+    appName: Lat Long export for {datasetId}
   all:
     appName: Lat Long export for datasets
     runner: SparkRunner
@@ -61,7 +65,7 @@ sample:
     # TODO
 # java -Xmx8g -Xmx8g -XX:+UseG1GC
   embedded:
-    appName: SamplingToAvro indexing for {0}
+    appName: SamplingToAvro indexing for {datasetId}
     runner: SparkRunner
     inputPath: /data/pipelines-data
     metaFileName: indexing-metrics.yml
@@ -81,7 +85,7 @@ migrate-uuids:
 # java -Xmx8g -Xmx8g -XX:+UseG1GC
 uuid:
   embedded:
-    appName: UUID minting for {0}
+    appName: UUID minting for {datasetId}
     runner: SparkRunner
     inputPath: /data/pipelines-data
     metaFileName: uuid-metrics.yml
@@ -101,7 +105,7 @@ index:
     # TODO
   # java -Xmx8g -Xmx8g -XX:+UseG1GC
   spark-embedded:
-    appName: SOLR indexing for {0}
+    appName: SOLR indexing for {datasetId}
     runner: SparkRunner
 #    properties: pipelines.properties
     zkHost: localhost:9983

--- a/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
+++ b/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 
 import java.io.FileNotFoundException;
 import java.util.LinkedHashMap;
+import java.util.concurrent.Callable;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -99,5 +100,31 @@ public class CombinedConfigurationTest {
   @Test
   public void testEmptyVarNotNull() {
     assertThat(testConf.get("general.hdfsSiteConfig"), equalTo(""));
+  }
+
+  public static Throwable exceptionOf(Callable<?> callable) {
+    try {
+      callable.call();
+      return null;
+    } catch (Throwable t) {
+      return t;
+    }
+  }
+
+  @Test
+  public void expectExceptionWhenMissingConf() throws FileNotFoundException {
+    assertThat(
+        exceptionOf(
+            () ->
+                new CombinedYamlConfiguration(
+                    new String[] {"--config=src/main/resources/missing-la-pipelines.yaml"})),
+        instanceOf(FileNotFoundException.class));
+  }
+
+  @Test
+  public void expectExceptionWhenMissingConfigArgument() throws FileNotFoundException {
+    assertThat(
+        exceptionOf(() -> new CombinedYamlConfiguration(new String[] {})),
+        instanceOf(RuntimeException.class));
   }
 }

--- a/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
+++ b/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
@@ -1,0 +1,70 @@
+package au.org.ala.utils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.hamcrest.Matchers;
+
+import java.io.FileNotFoundException;
+import java.util.LinkedHashMap;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class CombinedConfigurationTest {
+  private static CombinedYamlConfiguration testConf;
+
+  @BeforeClass
+  public static void loadConf() throws FileNotFoundException {
+    testConf = new CombinedYamlConfiguration("src/main/resources/la-pipelines.yaml");
+  }
+
+  @Test
+  public void getUnknowValueReturnsEmptyList() throws FileNotFoundException {
+    assertThat(((LinkedHashMap<String, Object>) testConf.subSet("general2")).size(), equalTo(0));
+  }
+  
+  @Test
+  public void weCanJoinSeveralConfigsAndConvertToArgs() {
+    String[] args = testConf.toArgs("general", "interpret.default", "interpret.spark-embedded");
+    // it should be --args=value arrays
+    assertThat(args.length, greaterThan(0));
+    LinkedHashMap<String, Object> argsInMap = new LinkedHashMap<>();
+    for (String arg : args) {
+      assertThat(arg.substring(0, 2), equalTo("--"));
+      String[] splitted = arg.substring(2).split("=");
+      assertThat(splitted.length, equalTo(2));
+      argsInMap.put(splitted[0], splitted[1]);
+    }
+    assertThat(argsInMap.get("interpretationTypes"), equalTo("ALL"));
+    assertThat(argsInMap.get("runner"), equalTo("SparkRunner"));
+    assertThat(argsInMap.get("attempt"), equalTo("1"));
+    assertThat(argsInMap.get("missingVar"), equalTo(null));
+    assertThat(argsInMap.get("missing.dot.var"), equalTo(null));
+  }
+
+  @Test
+  public void weCanJoinSeveralConfigs() {
+    LinkedHashMap<String, Object> embedConf = testConf.subSet("general", "interpret.default", "interpret.spark-embedded");
+    assertThat(embedConf.get("interpretationTypes"), equalTo("ALL"));
+    assertThat(embedConf.get("runner"), equalTo("SparkRunner"));
+    assertThat(embedConf.get("attempt"), equalTo(1));
+    assertThat(embedConf.get("missingVar"), equalTo(null));
+    assertThat(embedConf.get("missing.dot.var"), equalTo(null));
+    assertThat(embedConf.get("geocode.api.url"), equalTo("http://127.0.0.1:4444/geocode/%"));
+    assertThat(embedConf.get("geocode.api.url"), not("http://just-testing-matchers"));
+  }
+
+  @Test
+  public void rootVars() {
+    assertThat(testConf.subSet("test-delete").getClass(), equalTo(LinkedHashMap.class));
+    assertThat(testConf.subSet().get("test-delete"), equalTo(1));
+    assertThat(testConf.get("test-delete"), equalTo(1));
+  }
+
+  @Test
+  public void dotVars() {
+    assertThat(testConf.get("index.spark-embedded").getClass() , equalTo(LinkedHashMap.class));
+    assertThat(testConf.get("index.spark-embedded.includeSampling"), equalTo(true));
+    assertThat(testConf.get("index.spark-embedded.solrCollection"), equalTo("biocache"));
+  }
+}

--- a/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
+++ b/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
@@ -1,8 +1,7 @@
 package au.org.ala.utils;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import org.hamcrest.Matchers;
 
 import java.io.FileNotFoundException;
 import java.util.LinkedHashMap;
@@ -19,10 +18,10 @@ public class CombinedConfigurationTest {
   }
 
   @Test
-  public void getUnknowValueReturnsEmptyList() throws FileNotFoundException {
-    assertThat(((LinkedHashMap<String, Object>) testConf.subSet("general2")).size(), equalTo(0));
+  public void getUnknownValueReturnsEmptyList() throws FileNotFoundException {
+    assertThat(testConf.subSet("general2").size(), equalTo(0));
   }
-  
+
   @Test
   public void weCanJoinSeveralConfigsAndConvertToArgs() {
     String[] args = testConf.toArgs("general", "interpret.default", "interpret.spark-embedded");
@@ -44,7 +43,8 @@ public class CombinedConfigurationTest {
 
   @Test
   public void weCanJoinSeveralConfigs() {
-    LinkedHashMap<String, Object> embedConf = testConf.subSet("general", "interpret.default", "interpret.spark-embedded");
+    LinkedHashMap<String, Object> embedConf =
+        testConf.subSet("general", "interpret.default", "interpret.spark-embedded");
     assertThat(embedConf.get("interpretationTypes"), equalTo("ALL"));
     assertThat(embedConf.get("runner"), equalTo("SparkRunner"));
     assertThat(embedConf.get("attempt"), equalTo(1));
@@ -63,7 +63,7 @@ public class CombinedConfigurationTest {
 
   @Test
   public void dotVars() {
-    assertThat(testConf.get("index.spark-embedded").getClass() , equalTo(LinkedHashMap.class));
+    assertThat(testConf.get("index.spark-embedded").getClass(), equalTo(LinkedHashMap.class));
     assertThat(testConf.get("index.spark-embedded.includeSampling"), equalTo(true));
     assertThat(testConf.get("index.spark-embedded.solrCollection"), equalTo("biocache"));
   }

--- a/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
+++ b/pipelines/src/test/java/au/org/ala/utils/CombinedConfigurationTest.java
@@ -1,5 +1,6 @@
 package au.org.ala.utils;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -14,12 +15,24 @@ public class CombinedConfigurationTest {
 
   @BeforeClass
   public static void loadConf() throws FileNotFoundException {
-    testConf = new CombinedYamlConfiguration("src/main/resources/la-pipelines.yaml");
+    testConf =
+        new CombinedYamlConfiguration(
+            new String[] {
+              "--someArg=1",
+              "--runner=other",
+              "--datasetId=dr893",
+              "--config=src/main/resources/la-pipelines.yaml,src/main/resources/la-pipelines.yaml"
+            });
   }
 
   @Test
   public void getUnknownValueReturnsEmptyList() throws FileNotFoundException {
-    assertThat(testConf.subSet("general2").size(), equalTo(0));
+    assertThat(
+        new CombinedYamlConfiguration(
+                new String[] {"--config=src/main/resources/la-pipelines.yaml"})
+            .subSet("general2")
+            .size(),
+        equalTo(0));
   }
 
   @Test
@@ -27,26 +40,41 @@ public class CombinedConfigurationTest {
     String[] args = testConf.toArgs("general", "interpret.default", "interpret.spark-embedded");
     // it should be --args=value arrays
     assertThat(args.length, greaterThan(0));
-    LinkedHashMap<String, Object> argsInMap = new LinkedHashMap<>();
-    for (String arg : args) {
-      assertThat(arg.substring(0, 2), equalTo("--"));
-      String[] splitted = arg.substring(2).split("=");
-      assertThat(splitted.length, equalTo(2));
-      argsInMap.put(splitted[0], splitted[1]);
-    }
+    LinkedHashMap<String, Object> argsInMap = argsToMap(args);
     assertThat(argsInMap.get("interpretationTypes"), equalTo("ALL"));
-    assertThat(argsInMap.get("runner"), equalTo("SparkRunner"));
+    assertThat(argsInMap.get("runner"), equalTo("other")); // as main args has preference
     assertThat(argsInMap.get("attempt"), equalTo("1"));
     assertThat(argsInMap.get("missingVar"), equalTo(null));
     assertThat(argsInMap.get("missing.dot.var"), equalTo(null));
   }
 
+  @NotNull
+  private LinkedHashMap<String, Object> argsToMap(String[] args) {
+    LinkedHashMap<String, Object> argsInMap = new LinkedHashMap<>();
+    for (String arg : args) {
+      assertThat(arg.substring(0, 2), equalTo("--"));
+      String[] splitted = arg.substring(2).split("=", 2);
+      assertThat(splitted.length, equalTo(2));
+      argsInMap.put(splitted[0], splitted[1]);
+    }
+    return argsInMap;
+  }
+
+  @Test
+  public void weCanJoinSeveralConfigsAndConvertToArgsWithParams() {
+    String[] args = testConf.toArgs("general", "interpret.default", "interpret.spark-cluster");
+    LinkedHashMap<String, Object> argsInMap = argsToMap(args);
+    assertThat(argsInMap.get("name"), equalTo("interpret dr893"));
+    assertThat(argsInMap.get("appName"), equalTo("Interpretation for dr893"));
+    assertThat(argsInMap.get("inputPath"), equalTo("/data/pipelines-data/dr893/1/verbatim.avro"));
+  }
+
   @Test
   public void weCanJoinSeveralConfigs() {
     LinkedHashMap<String, Object> embedConf =
-        testConf.subSet("general", "interpret.default", "interpret.spark-embedded");
+        testConf.subSet("general", "services", "interpret.default", "interpret.spark-embedded");
     assertThat(embedConf.get("interpretationTypes"), equalTo("ALL"));
-    assertThat(embedConf.get("runner"), equalTo("SparkRunner"));
+    assertThat(embedConf.get("runner"), equalTo("other")); // as main args has preference
     assertThat(embedConf.get("attempt"), equalTo(1));
     assertThat(embedConf.get("missingVar"), equalTo(null));
     assertThat(embedConf.get("missing.dot.var"), equalTo(null));
@@ -66,5 +94,10 @@ public class CombinedConfigurationTest {
     assertThat(testConf.get("index.spark-embedded").getClass(), equalTo(LinkedHashMap.class));
     assertThat(testConf.get("index.spark-embedded.includeSampling"), equalTo(true));
     assertThat(testConf.get("index.spark-embedded.solrCollection"), equalTo("biocache"));
+  }
+
+  @Test
+  public void testEmptyVarNotNull() {
+    assertThat(testConf.get("general.hdfsSiteConfig"), equalTo(""));
   }
 }

--- a/pipelines/src/test/resources/pipelines-local.yaml
+++ b/pipelines/src/test/resources/pipelines-local.yaml
@@ -1,0 +1,7 @@
+# Here we can override some config from la-pipelines.yml instead of modifing it.
+# For instance:
+
+general:
+  targetPath: /some-other-moint-point/pipelines-data
+
+root-test2: 2

--- a/pipelines/src/test/resources/pipelines.yaml
+++ b/pipelines/src/test/resources/pipelines.yaml
@@ -4,3 +4,112 @@ alaNameMatch:
 collectory:
   wsUrl: https://collections.ala.org.au
   timeoutSec: 70
+
+services:
+  gbif.api.url: https://___DONT_USE______xapi.gbif.org
+  ala_taxonomy.api.url: http://localhost:9179
+  ala_spatial.api.url: http://localhost:8080
+  ala_collectory.api.url: https://collections.ala.org.au
+  ala_lists.api.url: http://lists.ala.org.au
+  geocode.api.url: http://127.0.0.1:4444/geocode/%
+
+general:
+  targetPath: /data/pipelines-data
+  attempt: 1
+  hdfsSiteConfig: ""
+  coreSiteConfig: ""
+
+dwca-avro:
+  runner: SparkRunner
+  metaFileName: dwca-metrics.yml
+  inputPath: /data/biocache-load/{datasetId}
+
+#--inputPath: $dwca_dir
+
+#java -Xmx2g -XX:+UseG1GC  -Dspark.master=local[*]
+# java -Xmx8g -XX:+UseG1GC  -Dspark.master=local[*] # spark-embedded
+interpret: # (java)
+  default:
+    interpretationTypes: ALL
+    inputPath: /data/pipelines-data/{datasetId}/1/verbatim.avro
+    metaFileName: interpretation-metrics.yml
+    useExtendedRecordId: true
+    skipRegisrtyCalls: true
+    #  properties: pipelines.properties
+  spark-cluster:
+    name: interpret {datasetId}
+    appName: Interpretation for {datasetId}
+    runner: SparkRunner
+    #--properties=/efs-mount-point/pipelines.properties
+    # num-executors: 24
+    # executor-cores: 8
+    # executor-memory: 7G
+    # driver-memory: 1G
+#--conf spark.default.parallelism=192
+#--conf spark.yarn.submit.waitAppCompletion=false
+    master: spark://172.30.1.102:7077
+    driver-java-options: -Dlog4j.configuration=file:/efs-mount-point/log4j.properties
+  spark-embedded:
+    runner: SparkRunner
+
+export-latlng:
+  inputPath: /data/pipelines-data
+  runner: SparkRunner
+  appName: Lat Long export for {datasetId}
+
+sample:
+  default:
+  cluster:
+    # TODO
+  avro-cluster:
+    # TODO
+# java -Xmx8g -Xmx8g -XX:+UseG1GC
+  embedded:
+    appName: SamplingToAvro indexing for {datasetId}
+    runner: SparkRunner
+    inputPath: /data/pipelines-data
+    metaFileName: indexing-metrics.yml
+#--properties=pipelines.properties
+
+#java -Xmx8g -Xmx8g -XX:+UseG1GC -
+migrate-uuids:
+  default:
+    runner: SparkRunner
+    metaFileName: uuid-metrics.yml
+    targetPath: /data/pipelines-data
+    inputPath: /data/pipelines-data/occ_uuid.csv
+  #java -Xmx24g -Xmx24g -XX:+UseG1GC
+  test:
+    runner: DirectRunner
+
+# java -Xmx8g -Xmx8g -XX:+UseG1GC
+uuid:
+  embedded:
+    appName: UUID minting for {datasetId}
+    runner: SparkRunner
+    inputPath: /data/pipelines-data
+    metaFileName: uuid-metrics.yml
+#--properties=pipelines.properties
+
+#java -Xmx8g -XX:+UseG1GC -
+index:
+  default:
+    inputPath: /data/pipelines-data
+    metaFileName: indexing-metrics.yml
+  java:
+    #--properties=pipelines.properties \
+    includeSampling: true
+    zkHost: localhost:9983
+    solrCollection: biocache
+  spark-cluster:
+    # TODO
+  # java -Xmx8g -Xmx8g -XX:+UseG1GC
+  spark-embedded:
+    appName: SOLR indexing for {datasetId}
+    runner: SparkRunner
+#    properties: pipelines.properties
+    zkHost: localhost:9983
+    solrCollection: biocache
+    includeSampling: true
+
+root-test: 1

--- a/scripts/dwca-avro.sh
+++ b/scripts/dwca-avro.sh
@@ -20,10 +20,4 @@ fi
 java -Dspark.local.dir=$SPARK_TMP \
 -cp $PIPELINES_JAR au.org.ala.pipelines.beam.DwcaToVerbatimPipeline \
   --datasetId=$1 \
-  --attempt=1 \
-  --runner=SparkRunner \
-  --metaFileName=dwca-metrics.yml \
-  --targetPath=$FS_PATH/$DATA_DIR \
-  --hdfsSiteConfig=$HDFS_CONF \
-  --coreSiteConfig=$HDFS_CONF \
-  --inputPath=$dwca_dir
+  --config=../pipelines/src/main/resources/la-pipelines.yaml

--- a/scripts/dwca-avro.sh
+++ b/scripts/dwca-avro.sh
@@ -20,4 +20,4 @@ fi
 java -Dspark.local.dir=$SPARK_TMP \
 -cp $PIPELINES_JAR au.org.ala.pipelines.beam.DwcaToVerbatimPipeline \
   --datasetId=$1 \
-  --config=../pipelines/src/main/resources/la-pipelines.yaml
+  --config=../configs/la-pipelines.yaml,../configs/la-pipelines-local.yaml

--- a/scripts/export-latlng-cluster.sh
+++ b/scripts/export-latlng-cluster.sh
@@ -17,11 +17,5 @@ fi
 --master $SPARK_MASTER \
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
---appName="Lat Long export for $1" \
 --datasetId=$1 \
---attempt=1 \
---runner=SparkRunner \
---inputPath=$FS_PATH/$DATA_DIR \
---targetPath=$FS_PATH/$DATA_DIR \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF
+--config=../pipelines/src/main/resources/la-pipelines.yaml

--- a/scripts/export-latlng-cluster.sh
+++ b/scripts/export-latlng-cluster.sh
@@ -18,4 +18,4 @@ fi
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
 --datasetId=$1 \
---config=../pipelines/src/main/resources/la-pipelines.yaml
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-local.yaml

--- a/scripts/export-latlng-embedded.sh
+++ b/scripts/export-latlng-embedded.sh
@@ -9,5 +9,4 @@ fi
 
 java -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALAInterpretedToLatLongCSVPipeline \
  --datasetId=$1 \
- --config=../pipelines/src/main/resources/la-pipelines.yaml
-
+ --config=../configs/la-pipelines.yaml,../configs/la-pipelines-local.yaml

--- a/scripts/export-latlng-embedded.sh
+++ b/scripts/export-latlng-embedded.sh
@@ -8,12 +8,6 @@ if [ $# -eq 0 ]
 fi
 
 java -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALAInterpretedToLatLongCSVPipeline \
- --appName="Lat Long export for $1" \
  --datasetId=$1 \
- --attempt=1 \
- --runner=SparkRunner \
- --inputPath=$FS_PATH/$DATA_DIR \
- --targetPath=$FS_PATH/$DATA_DIR \
- --coreSiteConfig=$HDFS_CONF \
- --hdfsSiteConfig=$HDFS_CONF
+ --config=../pipelines/src/main/resources/la-pipelines.yaml
 

--- a/scripts/index-java.sh
+++ b/scripts/index-java.sh
@@ -13,16 +13,7 @@ SECONDS=0
 
 java -Xmx8g -XX:+UseG1GC -cp $PIPELINES_JAR au.org.ala.pipelines.java.ALAInterpretedToSolrIndexPipeline \
 --datasetId=$1 \
---attempt=1 \
---inputPath=$FS_PATH/$DATA_DIR \
---targetPath=$FS_PATH/$DATA_DIR \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF \
---metaFileName=indexing-metrics.yml \
---properties=$PIPELINES_CONF \
---zkHost=$SOLR_ZK_HOST \
---solrCollection=$SOLR_COLLECTION \
---includeSampling=true
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/index-spark-cluster.sh
+++ b/scripts/index-spark-cluster.sh
@@ -22,19 +22,8 @@ SECONDS=0
 --master $SPARK_MASTER \
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
---appName="SOLR indexing for $1" \
 --datasetId=$1 \
---attempt=1 \
---runner=SparkRunner \
---inputPath=$FS_PATH/$DATA_DIR \
---targetPath=$FS_PATH/$DATA_DIR \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF \
---metaFileName=indexing-metrics.yml \
---properties=$PIPELINES_CONF \
---includeSampling=true \
---zkHost=$SOLR_ZK_HOST \
---solrCollection=$SOLR_COLLECTION
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-cluster.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/index-spark-embedded.sh
+++ b/scripts/index-spark-embedded.sh
@@ -9,16 +9,5 @@ if [ $# -eq 0 ]
 fi
 
 java -Xmx8g -Xmx8g -XX:+UseG1GC -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALAInterpretedToSolrIndexPipeline \
- --appName="SOLR indexing for $1" \
  --datasetId=$1 \
- --attempt=1 \
- --runner=SparkRunner \
- --inputPath=$FS_PATH/$DATA_DIR \
- --targetPath=$FS_PATH/$DATA_DIR \
- --coreSiteConfig=$HDFS_CONF \
- --hdfsSiteConfig=$HDFS_CONF \
- --metaFileName=indexing-metrics.yml \
- --properties=$PIPELINES_CONF \
- --zkHost=$SOLR_ZK_HOST \
- --solrCollection=$SOLR_COLLECTION  \
- --includeSampling=true
+ --config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-embedded.yaml,../configs/la-pipelines-local.yaml

--- a/scripts/interpret-java.sh
+++ b/scripts/interpret-java.sh
@@ -7,16 +7,7 @@ echo $(date)
 SECONDS=0
 java -Xmx1g -XX:+UseG1GC  -Dspark.master=local[*]  -cp $PIPELINES_JAR au.org.ala.pipelines.java.ALAVerbatimToInterpretedPipeline \
 --datasetId=$1 \
---attempt=1 \
---interpretationTypes=ALL \
---runner=SparkRunner \
---targetPath=$FS_PATH/$DATA_DIR \
---inputPath=$FS_PATH/$DATA_DIR/$1/1/verbatim.avro \
---metaFileName=interpretation-metrics.yml \
---properties=$PIPELINES_CONF \
---useExtendedRecordId=true \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/interpret-spark-cluster.sh
+++ b/scripts/interpret-spark-cluster.sh
@@ -22,6 +22,7 @@ SECONDS=0
 --master $SPARK_MASTER \
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
+--datasetId=$1 \
 --config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-cluster.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)

--- a/scripts/interpret-spark-cluster.sh
+++ b/scripts/interpret-spark-cluster.sh
@@ -22,18 +22,7 @@ SECONDS=0
 --master $SPARK_MASTER \
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
---appName="Interpretation for $1" \
---datasetId=$1 \
---attempt=1 \
---interpretationTypes=ALL \
---runner=SparkRunner \
---targetPath=$FS_PATH/$DATA_DIR \
---inputPath=$FS_PATH/$DATA_DIR/$1/1/verbatim.avro \
---metaFileName=interpretation-metrics.yml \
---properties=$PIPELINES_CONF \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF \
---useExtendedRecordId=true
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-cluster.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/interpret-spark-embedded.sh
+++ b/scripts/interpret-spark-embedded.sh
@@ -12,6 +12,7 @@ fi
 echo $(date)
 SECONDS=0
 java -Xmx8g -XX:+UseG1GC  -Dspark.master=local[*]  -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALAVerbatimToInterpretedPipeline \
+--datasetId=$1 \
 --config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-embedded.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)

--- a/scripts/interpret-spark-embedded.sh
+++ b/scripts/interpret-spark-embedded.sh
@@ -12,17 +12,7 @@ fi
 echo $(date)
 SECONDS=0
 java -Xmx8g -XX:+UseG1GC  -Dspark.master=local[*]  -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALAVerbatimToInterpretedPipeline \
---datasetId=$1 \
---attempt=1 \
---interpretationTypes=ALL \
---runner=SparkRunner \
---targetPath=$FS_PATH/$DATA_DIR \
---inputPath=$FS_PATH/$DATA_DIR/$1/1/verbatim.avro \
---metaFileName=interpretation-metrics.yml \
---properties=$PIPELINES_CONF \
---useExtendedRecordId=true \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-embedded.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/sample-avro-cluster.sh
+++ b/scripts/sample-avro-cluster.sh
@@ -21,18 +21,8 @@ SECONDS=0
 --master $SPARK_MASTER \
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
---appName="Add Sampling for $1" \
 --datasetId=$1 \
---attempt=1 \
---interpretationTypes=ALL \
---runner=SparkRunner \
---inputPath=$FS_PATH/$DATA_DIR \
---targetPath=$FS_PATH/$DATA_DIR \
---metaFileName=interpretation-metrics.yml \
---properties=$PIPELINES_CONF \
---useExtendedRecordId=true \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-cluster.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/sample-avro-embedded.sh
+++ b/scripts/sample-avro-embedded.sh
@@ -10,13 +10,5 @@ if [ $# -eq 0 ]
 fi
 
 java -Xmx8g -Xmx8g -XX:+UseG1GC  -cp $PIPELINES_JAR au.org.ala.pipelines.beam.ALASamplingToAvroPipeline \
- --appName="SamplingToAvro indexing for $1" \
- --datasetId=$1\
- --attempt=1 \
- --runner=SparkRunner \
- --inputPath=$FS_PATH/$DATA_DIR \
- --targetPath=$FS_PATH/$DATA_DIR \
- --coreSiteConfig=$HDFS_CONF \
- --hdfsSiteConfig=$HDFS_CONF \
- --metaFileName=indexing-metrics.yml \
- --properties=$PIPELINES_CONF
+ --datasetId=$1 \
+ --config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-embedded.yaml,../configs/la-pipelines-local.yaml

--- a/scripts/sample.sh
+++ b/scripts/sample.sh
@@ -8,13 +8,5 @@ if [ $# -eq 0 ]
 fi
 
 java -Xmx8g -Xmx8g -XX:+UseG1GC -cp $PIPELINES_JAR au.org.ala.sampling.LayerCrawler \
- --appName="Sample for $1" \
  --datasetId=$1 \
- --attempt=1 \
- --runner=SparkRunner \
- --inputPath=$FS_PATH/$DATA_DIR \
- --targetPath=$FS_PATH/$DATA_DIR \
- --coreSiteConfig=$HDFS_CONF \
- --hdfsSiteConfig=$HDFS_CONF \
- --metaFileName=indexing-metrics.yml \
- --properties=$PIPELINES_CONF
+ --config=../configs/la-pipelines.yaml,../configs/la-pipelines-local.yaml

--- a/scripts/uuid-spark-cluster.sh
+++ b/scripts/uuid-spark-cluster.sh
@@ -21,19 +21,8 @@ SECONDS=0
 --master $SPARK_MASTER \
 --driver-java-options "-Dlog4j.configuration=file:/efs-mount-point/log4j.properties" \
 $PIPELINES_JAR \
---appName="UUID minting for $1" \
 --datasetId=$1 \
---attempt=1 \
---interpretationTypes=ALL \
---runner=SparkRunner \
---inputPath=$FS_PATH/$DATA_DIR \
---targetPath=$FS_PATH/$DATA_DIR \
---coreSiteConfig=$HDFS_CONF \
---hdfsSiteConfig=$HDFS_CONF \
---metaFileName=uuid-metrics.yml \
---properties=$PIPELINES_CONF \
---useExtendedRecordId=true \
---skipRegisrtyCalls=true
+--config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-cluster.yaml,../configs/la-pipelines-local.yaml
 
 echo $(date)
 duration=$SECONDS

--- a/scripts/uuid-spark-embedded.sh
+++ b/scripts/uuid-spark-embedded.sh
@@ -11,13 +11,5 @@ if [ $# -eq 0 ]
 fi
 
 java -Xmx8g -Xmx8g -XX:+UseG1GC  -cp $PIPELINES_JAR  au.org.ala.pipelines.beam.ALAUUIDMintingPipeline \
- --appName="UUID minting for $1" \
  --datasetId=$1\
- --attempt=1 \
- --runner=SparkRunner \
- --inputPath=$FS_PATH/$DATA_DIR \
- --targetPath=$FS_PATH/$DATA_DIR \
- --coreSiteConfig=$HDFS_CONF \
- --hdfsSiteConfig=$HDFS_CONF \
- --metaFileName=uuid-metrics.yml \
- --properties=$PIPELINES_CONF
+ --config=../configs/la-pipelines.yaml,../configs/la-pipelines-spark-embedded.yaml,../configs/la-pipelines-local.yaml


### PR DESCRIPTION
As a first part of creating a CLI for `la-pipelines`, see #88 , and also in order to generate a debian package with a reference configuration, I've externalized the main args to a `la-pipelines.yaml` and I added a `--config` to reference it. 

The config is a list of yaml files comma separated, although you can still use the previous args.

For instance I can test some entry point with:
```
--datasetId=dr893 --config=configs/la-pipelines.yaml,configs/la-pipelines-local.yaml --properties=scripts/pipelines.yaml
```

See a run screenshot:

![2020-11-07-23:44:50-run](https://user-images.githubusercontent.com/180085/86846970-e577dd80-c0ab-11ea-97f5-8a6b2f838374.png)

The last args has precedence over the yaml configs, and `la-pipelines-local.yaml` has precedence to `la-pipelines.yaml`.

I tested also using the `scripts`.

The idea to write (via ansible, for instance) each node configuration the `la-pipelines-local.yaml` configuration instead of modifying `la-pipelines.yml`. This is useful during packages upgrades to maintain that file uptodate and in sync with the software and prevent the typical upgrade questions:
https://i.stack.imgur.com/Sm3Ld.jpg
also is a good way to provide a reference uptodate configuration to docker based portals.

TODO: Take into account the set-env scripts to take into account HDFS etc.